### PR TITLE
Fixes callbacks for chrome.storage

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -5,19 +5,14 @@
 
 (function () {
     // get second instance of spacer class in menuArea
-    let stateOptions = $(".menuarea").find('.selected'); 
+    const currentlySelected = $(".menuarea .spacer:last-child .selected").text();
 
-    // figure out how to get the value from chrome storage
-    let defaultState = chrome.storage.local.get("storedState", function(result) {
-        defaultState = result.value;
+    chrome.storage.local.get("storedState", function({storedState}) {
+        // only change webpage if state is not the one in memory
+        const sameAsSelected = currentlySelected.includes(storedState);
+        if (!sameAsSelected) {
+            const [insteadClick] = $(`a.choice:contains("${storedState}")`);
+            insteadClick.click();
+        }
     });
-
-    // only change webpage if state is not the one in memory
-    if (!stateOptions.text().includes(defaultState)) {
-        let newOption = $("a.choice:contains(" + defaultState + ")");
-
-        newOption[0].click(function() {
-            window.location.href = newOption.attr('href');
-        });
-    }
 })();

--- a/js/stateController.js
+++ b/js/stateController.js
@@ -4,7 +4,7 @@
 let myApp = angular.module("myApp", []);
 
 myApp.controller("stateController", function($scope) {
-    
+
     // I think this initializes the state
     $scope.selectedState = "All States";
 
@@ -15,7 +15,7 @@ myApp.controller("stateController", function($scope) {
         // Save it using the Chrome extension storage API.
         chrome.storage.local.set({'storedState': $scope.selectedState}, function() {
             chrome.storage.local.get("storedState", function(result) {
-                console.log(data);
+                console.log(result);
             });
             console.log('Settings saved');
         });


### PR DESCRIPTION
Adjusted the chrome.storage code so it uses the callbacks properly. If you'd prefer to use synced storage over local storage, replace `chrome.storage.local` with `chrome.storage.sync` but leave the rest of the code intact.

I additionally adjusted the selector code so it gets the state selector instead of the country selector.